### PR TITLE
[FIX] keys map not being set correctly

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -108,6 +108,7 @@ class Hiera
               if key_to_use.nil? 
                 raise RecoverableError, "No key found on keyring for #{r}"
               end
+              key_to_use
             }
             debug("Keys: #{keys}")
 


### PR DESCRIPTION
Hi 

(second try with rebased commit)

Just a quick fix for a bug I found when encrypting. Looks like the recent 0.3 patch doesn't map the recipient keys correctly leading to the following error,

```
/Library/Ruby/Gems/1.8/gems/hiera-eyaml-gpg-0.3/lib/hiera/backend/eyaml/encryptors/gpg.rb:108:in encrypt': undefined local variable or methodkey' for Hiera::Backend::Eyaml::Encryptors::Gpg:Class (NameError)
from /Library/Ruby/Gems/1.8/gems/hiera-eyaml-gpg-0.3/lib/hiera/backend/eyaml/encryptors/gpg.rb:106:in map'
from /Library/Ruby/Gems/1.8/gems/hiera-eyaml-gpg-0.3/lib/hiera/backend/eyaml/encryptors/gpg.rb:106:inencrypt'
from /Library/Ruby/Gems/1.8/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb:20:in decrypted_value'
from /Library/Ruby/Gems/1.8/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb:120:increate_token'
from /Library/Ruby/Gems/1.8/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/parser/parser.rb:71:in `parse_sca
```
