### PR TITLE
Correct an inaccurrate error message.

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -158,8 +158,8 @@ class Hiera
               txt.seek 0
               txt.read
             else
-              warn("No usable keys found in #{ENV['GNUPGHOME']}. Check :gpgpghome value in hiera.yaml is correct")
-              raise ArgumentError, "No usable keys found in #{ENV['GNUPGHOME']}. Check :gpgpghome value in hiera.yaml is correct"
+              warn("No usable keys found in #{ENV['GNUPGHOME']}. Check :gpg_gnupghome value in hiera.yaml is correct")
+              raise ArgumentError, "No usable keys found in #{ENV['GNUPGHOME']}. Check :gpg_gnupghome value in hiera.yaml is correct"
             end
           end
 


### PR DESCRIPTION
The error message formerly referenced the 'gpgpghome' key in hiera.yaml,
but the acutal key is 'gpg_gnupghome'.
