### PR TITLE
[#80633966] Set GPG home directory without an environment variable

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -93,8 +93,9 @@ class Hiera
           end
 
           def self.encrypt plaintext
-            ENV["GNUPGHOME"] = self.option :gnupghome
-            debug("GNUPGHOME is #{ENV['GNUPGHOME']}")
+            gnupghome = self.option :gnupghome
+            GPGME::Engine.home_dir = gnupghome
+            debug("GNUPGHOME is #{gnupghome}")
 
             ctx = GPGME::Ctx.new
 
@@ -132,8 +133,9 @@ class Hiera
           end
 
           def self.decrypt ciphertext
-            ENV["GNUPGHOME"] = self.option :gnupghome
-            debug("GNUPGHOME is #{ENV['GNUPGHOME']}")
+            gnupghome = self.option :gnupghome
+            GPGME::Engine.home_dir = gnupghome
+            debug("GNUPGHOME is #{gnupghome}")
 
             ctx = if hiera?
               GPGME::Ctx.new
@@ -158,8 +160,8 @@ class Hiera
               txt.seek 0
               txt.read
             else
-              warn("No usable keys found in #{ENV['GNUPGHOME']}. Check :gpg_gnupghome value in hiera.yaml is correct")
-              raise ArgumentError, "No usable keys found in #{ENV['GNUPGHOME']}. Check :gpg_gnupghome value in hiera.yaml is correct"
+              warn("No usable keys found in #{gnupghome}. Check :gpg_gnupghome value in hiera.yaml is correct")
+              raise ArgumentError, "No usable keys found in #{gnupghome}. Check :gpg_gnupghome value in hiera.yaml is correct"
             end
           end
 


### PR DESCRIPTION
Previously, `gpg.rb` was setting `ENV['GNUPGHOME']` to set GPG's home
directory, which contains the GPG keyring used by Hiera eYAML GPG, for
the `ruby-gpgme` gem.

This caused problems on our Puppet installation as we have other Puppet
resources that use GPG, such as our [puppet-aptly](https://github.com/gds-operations/puppet-aptly) module among others.

Because the `ruby` process that runs Puppet also includes Hiera eYAML
GPG, the `GNUPGHOME` environment variable was present throughout the
Puppet run, meaning that our other Puppet resources were using Hiera
eYAML GPG's `:gnupghome` as their GPG home directory.

I was able to verify this by creating a temporary `exec` resource that
prints the environment variables visible to Puppet, i.e.:

```
exec { 'test':
  command   => 'env',
  logoutput => true,
}
```

This commit changes this so that we now specify the home directory using
`GPGME::Engine.home_dir`[1](https://github.com/ueno/ruby-gpgme/blob/fc299c9c1fb52ce64d288fce4a00db6e9ea79192/lib/gpgme/engine.rb#L63-L70) rather than use an environment variable.

I'd hoped to add some Rspec integration tests to verify this, but hit a
number of issues, so resorted to testing this manually in Vagrant. The
environment variable is no longer set, and the GPG home directory is
correctly set. The environment now looks like:

```
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: LANGUAGE=en_US:
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: TERM=vt100
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: LANG=en_US.utf8
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: SHELL=/bin/bash
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: USERNAME=root
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: MAIL=/var/mail/root
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: SUDO_COMMAND=/usr/bin/puppet apply /var/govuk/puppet/manifests/site.pp --trusted_node_data --environment vagrant --modulepath /var/govuk/puppet/modules:/var/govuk/puppet/vendor/modules --manifestdir /var/govuk/puppet/manifests --hiera_config /var/govuk/puppet/hiera.yml
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: SUDO_USER=root
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: SUDO_UID=0
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: SUDO_GID=0
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: RBENV_VERSION=1.9.3
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: DEBIAN_FRONTEND=noninteractive
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: APT_LISTBUGS_FRONTEND=none
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: APT_LISTCHANGES_FRONTEND=none
==> cache-2.router: Notice: /Stage[main]/Main/Exec[test]/returns: executed successfully
```
