### PR TITLE
Adapt code for Puppetserver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org/'
 
 gem 'hiera-eyaml', ">=1.3.8"
-gem 'gpgme', ">=2.0.0"
 
 group :development do
   gem "aruba"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You will also need to install either the `gpgme` (recommended) or `ruby_gpg` gem
 
 OR
 
-    $ gem install ruby_gpg
+    $ gem install ruby_gpg -v ">=0.3.1"
 
 Note: you will need to use `ruby_gpg` with the Puppet server as it uses JRuby which cannot
 make use of native extensions such as `gpgme`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ To get started, install the hiera-eyaml-gpg gem.
 
     $ gem install hiera-eyaml-gpg
 
+You will also need to install either the `gpgme` (recommended) or `ruby_gpg` gem:
+
+    $ gem install gpgme
+
+OR
+
+    $ gem install ruby_gpg
+
+Note: you will need to use `ruby_gpg` with the Puppet server as it uses JRuby which cannot
+make use of native extensions such as `gpgme`.
+
 If you haven't already installed it, this requires and will install the hiera-eyaml gem, which you
 should probably acquint yourself with at https://github.com/TomPoulton/hiera-eyaml.
 

--- a/hiera-eyaml-gpg.gemspec
+++ b/hiera-eyaml-gpg.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency('hiera-eyaml', '>=1.3.8')
-  gem.add_dependency('gpgme', '>=2.0.0')
 end

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -1,10 +1,10 @@
 begin
   require 'gpgme'
-  gpg_impl = :gpgme
+  @gpg_impl = :gpgme
 rescue LoadError
   # Default to ruby_gpg
   require 'ruby_gpg'
-  gpg_impl = :ruby_gpg
+  @gpg_impl = :ruby_gpg
 end
 
 require 'base64'
@@ -107,7 +107,7 @@ class Hiera
             recipients = self.find_recipients
             debug("Recipents are #{recipients}")
 
-            if gpg_impl == :ruby_gpg
+            if @gpg_impl == :ruby_gpg
               RubyGpg.config.homedir = gnupghome if gnupghome
               return RubyGpg.encrypt_string(plaintext, recipients)
             end
@@ -150,7 +150,7 @@ class Hiera
             gnupghome = self.option :gnupghome
             debug("GNUPGHOME is #{gnupghome}")
 
-            if gpg_impl == :ruby_gpg
+            if @gpg_impl == :ruby_gpg
               RubyGpg.config.homedir = gnupghome if gnupghome
               RubyGpg.decrypt_string(ciphertext)
             end

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -1,8 +1,11 @@
 begin
   require 'gpgme'
 rescue LoadError
-  # Default to ruby_gpg
-  require 'ruby_gpg'
+  begin
+    require 'ruby_gpg'
+  rescue LoadError
+    fail "hiera-eyaml-gpg requires either the 'gpgme' or 'ruby_gpg' gem"
+  end
 end
 
 require 'base64'

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -1,10 +1,8 @@
 begin
   require 'gpgme'
-  @gpg_impl = :gpgme
 rescue LoadError
   # Default to ruby_gpg
   require 'ruby_gpg'
-  @gpg_impl = :ruby_gpg
 end
 
 require 'base64'
@@ -107,7 +105,7 @@ class Hiera
             recipients = self.find_recipients
             debug("Recipents are #{recipients}")
 
-            if @gpg_impl == :ruby_gpg
+            unless defined?(GPGME)
               RubyGpg.config.homedir = gnupghome if gnupghome
               return RubyGpg.encrypt_string(plaintext, recipients)
             end
@@ -150,7 +148,7 @@ class Hiera
             gnupghome = self.option :gnupghome
             debug("GNUPGHOME is #{gnupghome}")
 
-            if @gpg_impl == :ruby_gpg
+            unless defined?(GPGME)
               RubyGpg.config.homedir = gnupghome if gnupghome
               RubyGpg.decrypt_string(ciphertext)
             end

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -150,7 +150,7 @@ class Hiera
 
             unless defined?(GPGME)
               RubyGpg.config.homedir = gnupghome if gnupghome
-              RubyGpg.decrypt_string(ciphertext)
+              return RubyGpg.decrypt_string(ciphertext)
             end
 
             GPGME::Engine.home_dir = gnupghome

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -102,20 +102,18 @@ class Hiera
           end
 
           def self.encrypt plaintext
+            unless defined?(GPGME)
+              raise RecoverableError, "Encryption is only supported when using the 'gpgme' gem"
+            end
+
             gnupghome = self.option :gnupghome
+            GPGME::Engine.home_dir = gnupghome
             debug("GNUPGHOME is #{gnupghome}")
+
+            ctx = GPGME::Ctx.new
 
             recipients = self.find_recipients
             debug("Recipents are #{recipients}")
-
-            unless defined?(GPGME)
-              RubyGpg.config.homedir = gnupghome if gnupghome
-              return RubyGpg.encrypt_string(plaintext, recipients)
-            end
-
-            GPGME::Engine.home_dir = gnupghome
-
-            ctx = GPGME::Ctx.new
 
             raise RecoverableError, 'No recipients provided, don\'t know who to encrypt to' if recipients.empty?
 


### PR DESCRIPTION
This aims to fix #23.

With this change, `gpgme` is no longer a required dependency. Instead, users should choose to install either `gpgme` or `ruby_gpg`, and the code will fallback to using `ruby_gpg` if `gpgme` is not available.


The decryption part on JRuby requires [this patch](https://github.com/blaix/ruby_gpg/pull/2). The encryption requires [this other patch](https://github.com/blaix/ruby_gpg/pull/1) if you want to use multiple recipients.
