### PR TITLE
Simplify default gnupghome value.

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -26,7 +26,7 @@ class Hiera
           self.options = {
             :gnupghome => { :desc => "Location of your GNUPGHOME directory",
                             :type => :string,
-                            :default => "#{ENV["HOME"]}/.gnupg" },
+                            :default => "#{ENV[["HOME", "HOMEPATH"].detect("/etc/puppet") { |h| ENV[h] != nil }]}/.gnupg" },
             :always_trust => { :desc => "Assume that used keys are fully trusted",
                                :type => :boolean,
                                :default => false },

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -26,7 +26,7 @@ class Hiera
           self.options = {
             :gnupghome => { :desc => "Location of your GNUPGHOME directory",
                             :type => :string,
-                            :default => "#{ENV[["HOME", "HOMEPATH"].detect("/etc/puppet") { |h| ENV[h] != nil }]}/.gnupg" },
+                            :default => "#{ENV[["HOME", "HOMEPATH"].detect("PWD") { |h| ENV[h] != nil }]}/.gnupg" },
             :always_trust => { :desc => "Assume that used keys are fully trusted",
                                :type => :boolean,
                                :default => false },

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -26,7 +26,7 @@ class Hiera
           self.options = {
             :gnupghome => { :desc => "Location of your GNUPGHOME directory",
                             :type => :string,
-                            :default => "#{ENV[["HOME", "HOMEPATH"].detect("PWD") { |h| ENV[h] != nil }]}/.gnupg" },
+                            :default => "#{ENV["HOME"]||ENV["HOMEPATH"]||ENV["PWD"]}/.gnupg" },
             :always_trust => { :desc => "Assume that used keys are fully trusted",
                                :type => :boolean,
                                :default => false },

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -26,7 +26,7 @@ class Hiera
           self.options = {
             :gnupghome => { :desc => "Location of your GNUPGHOME directory",
                             :type => :string,
-                            :default => "#{ENV[["HOME", "HOMEPATH"].detect { |h| ENV[h] != nil }]}/.gnupg" },
+                            :default => "#{ENV["HOME"]}/.gnupg" },
             :always_trust => { :desc => "Assume that used keys are fully trusted",
                                :type => :boolean,
                                :default => false },


### PR DESCRIPTION
Was failing if $HOME and $HOMEPATH was not set.
This was particularly true when running puppet master as a Ubuntu service.