### PR TITLE
Add support for comments in hiera-eyaml-gpg.recipients file

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -94,7 +94,9 @@ class Hiera
               end
 
               unless recipient_file.nil?
-                recipient_file.readlines.map{ |line| line.strip } 
+                recipient_file.readlines.map{ |line|
+                  line.strip unless line.start_with? '#'
+                }.compact
               else
                 []
               end


### PR DESCRIPTION
This commit adds support for comments in the abovementioned file, so that we
do something like the following:

  #user1@example.com
  0x12345678
  #user2@example.com
  0x12348765