### PR TITLE
Improve GPG home handling

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -26,7 +26,7 @@ class Hiera
           self.options = {
             :gnupghome => { :desc => "Location of your GNUPGHOME directory",
                             :type => :string,
-                            :default => "#{ENV[["HOME", "HOMEPATH"].detect { |h| ENV[h] != nil }]}/.gnupg" },
+                            :default => "#{["HOME", "HOMEPATH"].reject { |h| ENV[h].nil? }.map { |h| ENV[h]+"/.gnupg" }.first || ""}",
             :always_trust => { :desc => "Assume that used keys are fully trusted",
                                :type => :boolean,
                                :default => false },
@@ -60,7 +60,7 @@ class Hiera
           def self.gnupghome
             gnupghome = self.option :gnupghome
             debug("GNUPGHOME is #{gnupghome}")
-            if gnupghome.nil?
+            if gnupghome.nil? || gnupghome.empty?
               warn("No GPG home directory configured, check gpg_gnupghome configuration value is correct")
               raise ArgumentError, "No GPG home directory configured, check gpg_gnupghome configuration value is correct"
             elsif !File.directory?(gnupghome)


### PR DESCRIPTION
This is a response to PRs #16 and #28.

The default is improved to return empty string in the case that neither environment variable is set.

In addition the error handling is better for dealing with the case when no GPG home directory is set or can be derived.

I've tested this locally but would be interested in any feedback from @freddo411, @robbat2 and @dann7387 before I merge and release.